### PR TITLE
fix(preprocess): summarize deleted files to prevent context bloat

### DIFF
--- a/src/gac/preprocess.py
+++ b/src/gac/preprocess.py
@@ -213,13 +213,13 @@ def extract_filtered_file_summary(section: str, change_type: str | None = None) 
             match = re.search(r"diff --git a/(.*?) b/", line)
             if match:
                 filename = match.group(1)
-        elif "deleted file" in line:
+        elif line.startswith("deleted file"):
             summary_lines.append(line)
-        elif "new file" in line:
+        elif line.startswith("new file"):
             summary_lines.append(line)
         elif line.startswith("index "):
             summary_lines.append(line)
-        elif "Binary file" in line:
+        elif line.startswith("Binary file"):
             summary_lines.append("[Binary file change]")
             break
 
@@ -227,6 +227,8 @@ def extract_filtered_file_summary(section: str, change_type: str | None = None) 
     if not change_type and filename:
         if any(re.search(pattern, section) for pattern in FilePatterns.BINARY):
             change_type = "[Binary file change]"
+        elif is_deleted_file_section(section):
+            change_type = "[Deleted file]"
         elif is_lockfile_or_generated(filename):
             change_type = "[Lockfile/generated file change]"
         elif any(filename.endswith(ext) for ext in FilePatterns.MINIFIED_EXTENSIONS):
@@ -261,6 +263,10 @@ def should_filter_section(section: str) -> bool:
     if file_match:
         filename = file_match.group(1)
 
+        if is_deleted_file_section(section):
+            logger.info(f"Summarized deleted file: {filename}")
+            return True
+
         if any(filename.endswith(ext) for ext in FilePatterns.MINIFIED_EXTENSIONS):
             logger.info(f"Filtered out minified file by extension: {filename}")
             return True
@@ -278,6 +284,22 @@ def should_filter_section(section: str) -> bool:
             return True
 
     return False
+
+
+def is_deleted_file_section(section: str) -> bool:
+    """Check if a diff section represents a deleted file.
+
+    A pure deletion includes the entire previous file content as ``-`` lines,
+    which can bloat the AI context for no benefit — the filename plus the
+    fact of deletion is enough to write a useful commit message.
+
+    Args:
+        section: Diff section to check
+
+    Returns:
+        True if the section's header marks the file as deleted
+    """
+    return bool(re.search(r"^deleted file mode", section, re.MULTILINE))
 
 
 def is_lockfile_or_generated(filename: str) -> bool:

--- a/tests/test_preprocess_additional.py
+++ b/tests/test_preprocess_additional.py
@@ -11,6 +11,7 @@ from gac.diff_scoring import (
 )
 from gac.preprocess import (
     extract_filtered_file_summary,
+    is_deleted_file_section,
     is_lockfile_or_generated,
     is_minified_content,
     preprocess_diff,
@@ -180,6 +181,49 @@ Binary file
 """
             result = should_filter_section(section)
             assert result is True
+
+    def test_should_filter_section_deleted_file_strips_content(self):
+        """A staged deletion should be summarized, not include the full file body."""
+        body = "\n".join(f"-line {i} of deleted file content" for i in range(500))
+        section = (
+            "diff --git a/big_deleted.py b/big_deleted.py\n"
+            "deleted file mode 100644\n"
+            "index abcdef1..0000000\n"
+            "--- a/big_deleted.py\n"
+            "+++ /dev/null\n"
+            "@@ -1,500 +0,0 @@\n"
+            f"{body}\n"
+        )
+
+        assert is_deleted_file_section(section) is True
+        assert should_filter_section(section) is True
+
+        summary = extract_filtered_file_summary(section)
+        assert "big_deleted.py" in summary
+        assert "deleted file mode 100644" in summary
+        assert "[Deleted file]" in summary
+        # The original body must NOT survive into the summary.
+        assert "line 0 of deleted file content" not in summary
+        assert "line 499 of deleted file content" not in summary
+        # Sanity: summary is dramatically smaller than the input section.
+        assert len(summary) < len(section) / 10
+
+    def test_extract_filtered_file_summary_ignores_minus_line_with_deleted_substring(self):
+        """A `-` content line containing the words 'deleted file' must not leak into the summary."""
+        section = (
+            "diff --git a/notes.md b/notes.md\n"
+            "index 1111111..2222222 100644\n"
+            "--- a/notes.md\n"
+            "+++ b/notes.md\n"
+            "@@ -1,2 +1,1 @@\n"
+            "-We deleted file foo.py last week.\n"
+            "-new file was added too.\n"
+            "+Cleaned up.\n"
+        )
+        summary = extract_filtered_file_summary(section, "[Custom]")
+        assert "We deleted file foo.py last week." not in summary
+        assert "new file was added too." not in summary
+        assert "[Custom]" in summary
 
     def test_is_lockfile_or_generated_package_lock(self):
         """Test is_lockfile_or_generated with package-lock.json."""


### PR DESCRIPTION
Staged file deletions previously flowed through preprocessing untouched, sending every removed line to the AI as a `-` line and bloating the context window for large deletions (a 2000-line deletion ~= 99K chars).

Changes:
- Add `is_deleted_file_section` and treat deletions like binaries/lockfiles in `should_filter_section`, collapsing them to a short summary ("diff --git" header + mode + index + `[Deleted file]` marker).
- Fix latent substring bug in `extract_filtered_file_summary` where `"deleted file" in line` / `"new file" in line` / `"Binary file" in line` would match content lines containing those words. Anchored to `line.startswith(...)` so `-We deleted file foo.py` no longer leaks into the summary.
- Add two regression tests covering both the summarization path and the substring-leak fix.

Repro: a 99,052-char / 2,006-line deletion now collapses to 118 chars / 4 lines. All 3,005 non-integration tests pass; `make lint` clean.