### PR TITLE
docs: add configuration guide for all 35+ AI providers

### DIFF
--- a/.gac.env.example
+++ b/.gac.env.example
@@ -1,104 +1,267 @@
 # gac Configuration Example
+# Copy this file to .gac.env and customize for your environment
+# Configuration priority: .gac.env (project) > ~/.gac.env (global) > environment variables
 
-# REQUIRED - Fully qualified model in format 'provider:model'
-# GAC_MODEL=claude-code:claude-sonnet-4-5
-# GAC_MODEL=custom-anthropic:claude-haiku-4-5
-# GAC_MODEL=custom-openai:gpt-4
+# =============================================================================
+# REQUIRED: Model Selection
+# =============================================================================
+# Format: provider:model-name
+# Run 'uvx gac model' for interactive selection, or see docs/en/PROVIDERS.md for all options
+
+# Popular choices (uncomment one):
+# GAC_MODEL=anthropic:claude-3-5-sonnet-20241022
+# GAC_MODEL=openai:gpt-4o
+# GAC_MODEL=groq:llama-3.3-70b-versatile
+# GAC_MODEL=ollama:llama3.1
 # GAC_MODEL=deepseek:deepseek-chat
-# GAC_MODEL=groq:meta-llama/llama-4-scout-17b-16e-instruct
-# GAC_MODEL=kimi-for-coding:kimi-coding
-# GAC_MODEL=minimax:abab6.5s-chat
-# GAC_MODEL=moonshot:moonshot-v1-8k
+# GAC_MODEL=gemini:gemini-1.5-pro
 # GAC_MODEL=mistral:mistral-large-latest
-# GAC_MODEL=replicate:openai/gpt-oss-120b
-# GAC_MODEL=together:meta-llama/Llama-3.2-3B-Instruct-Turbo
+# GAC_MODEL=azure-openai:my-deployment-name
+# GAC_MODEL=custom-openai:gpt-4
+# GAC_MODEL=custom-anthropic:claude-3-5-sonnet-20241022
 
+# =============================================================================
 # AI Provider API Keys
+# =============================================================================
 # Uncomment and add your key for the provider(s) you want to use
-# ANTHROPIC_API_KEY=your_key_here
-# CEREBRAS_API_KEY=your_key_here
-# CLAUDE_CODE_ACCESS_TOKEN=your_token_here  # OAuth token for Claude Code subscription users
-# CUSTOM_ANTHROPIC_API_KEY=your_key_here  # For custom Anthropic-compatible endpoints
-# CUSTOM_OPENAI_API_KEY=your_key_here  # For custom OpenAI-compatible endpoints
-# DEEPSEEK_API_KEY=your_key_here
-# GEMINI_API_KEY=your_key_here
-# GROQ_API_KEY=your_key_here
-# KIMI_API_KEY=your_key_here
-# LMSTUDIO_API_KEY=your_key_here  # Optional - only if your LM Studio instance requires authentication
-# MINIMAX_API_KEY=your_key_here
-# MOONSHOT_API_KEY=your_key_here
-# MISTRAL_API_KEY=your_key_here
-# OLLAMA_API_KEY=your_key_here  # Optional - only if your Ollama instance requires authentication
-# OPENAI_API_KEY=your_key_here
-# OPENROUTER_API_KEY=your_key_here
-# REPLICATE_API_TOKEN=your_token_here
-# SYNTHETIC_API_KEY=your_key_here
-# TOGETHER_API_KEY=your_key_here
-# WAFER_API_KEY=your_key_here
-# ZAI_API_KEY=your_key_here
 
-# AI Provider URLs
-# Uncomment and customize if you're using custom endpoints
-# CUSTOM_ANTHROPIC_BASE_URL=https://your-proxy.example.com  # Required for custom-anthropic provider
-# CUSTOM_ANTHROPIC_VERSION=2023-06-01  # Optional - API version header for custom-anthropic
-# CUSTOM_OPENAI_BASE_URL=https://your-endpoint.example.com  # Required for custom-openai provider
-# LMSTUDIO_API_URL=http://localhost:1234  # LM Studio server URL
-# OLLAMA_API_URL=http://localhost:11434  # Ollama server URL
-# WAFER_BASE_URL=https://pass.Wafer.ai  # Optional - Override Wafer.ai API base URL
+# Anthropic (Claude)
+# ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
 
+# Azure OpenAI
+# AZURE_OPENAI_API_KEY=xxxxxxxxxxxx
+# AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com
+# AZURE_OPENAI_API_VERSION=2024-10-21
 
-# OPTIONAL - gac Settings
+# Cerebras
+# CEREBRAS_API_KEY=csk-xxxxxxxxxxxx
+# CEREBRAS_BASE_URL=https://api.cerebras.ai/v1
+
+# Chutes.ai
+# CHUTES_API_KEY=chutes_xxxxxxxxxxxx
+# CHUTES_BASE_URL=https://llm.chutes.ai/v1
+
+# Claude Code (OAuth - configured via 'uvx gac init')
+# CLAUDE_CODE_ACCESS_TOKEN=your-oauth-token
+
+# Copilot (GitHub OAuth - configured via 'uvx gac init')
+# GITHUB_COPILOT_TOKEN=your-oauth-token
+
+# Crof.ai
+# CROF_API_KEY=crof_xxxxxxxxxxxx
+# CROF_BASE_URL=https://api.crof.ai/v1
+
+# Custom Anthropic-Compatible Endpoint
+# CUSTOM_ANTHROPIC_API_KEY=your-proxy-key
+# CUSTOM_ANTHROPIC_BASE_URL=https://your-proxy.example.com/v1
+# CUSTOM_ANTHROPIC_VERSION=2023-06-01
+
+# Custom OpenAI-Compatible Endpoint
+# CUSTOM_OPENAI_API_KEY=your-proxy-key
+# CUSTOM_OPENAI_BASE_URL=https://your-proxy.example.com/v1
+
+# DeepInfra
+# DEEPINFRA_API_KEY=your-key
+# DEEPINFRA_BASE_URL=https://api.deepinfra.com/v1/openai
+
+# DeepSeek
+# DEEPSEEK_API_KEY=sk-xxxxxxxxxxxx
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
+
+# Fireworks AI
+# FIREWORKS_API_KEY=fw_xxxxxxxxxxxx
+# FIREWORKS_BASE_URL=https://api.fireworks.ai/inference/v1
+
+# Google Gemini
+# GEMINI_API_KEY=your-gemini-key
+# GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+
+# Groq
+# GROQ_API_KEY=gsk_xxxxxxxxxxxx
+# GROQ_BASE_URL=https://api.groq.com/openai/v1
+
+# Kimi for Coding
+# KIMI_API_KEY=sk-xxxxxxxxxxxx
+# KIMI_BASE_URL=https://api.moonshot.cn/v1
+
+# Lilac
+# LILAC_API_KEY=your-key
+# LILAC_BASE_URL=https://api.lilac.ai/v1
+
+# LM Studio (Local)
+# LMSTUDIO_API_URL=http://localhost:1234
+# LMSTUDIO_API_KEY=your-key  # Optional
+
+# MiniMax
+# MINIMAX_API_KEY=your-key
+# MINIMAX_BASE_URL=https://api.minimax.chat/v1
+
+# Mistral AI
+# MISTRAL_API_KEY=your-key
+# MISTRAL_BASE_URL=https://api.mistral.ai/v1
+
+# Moonshot AI
+# MOONSHOT_API_KEY=sk-xxxxxxxxxxxx
+# MOONSHOT_BASE_URL=https://api.moonshot.cn/v1
+
+# Neuralwatt
+# NEURALWATT_API_KEY=your-key
+# NEURALWATT_BASE_URL=https://api.neuralwatt.ai/v1
+
+# Ollama (Local)
+# OLLAMA_API_URL=http://localhost:11434
+# OLLAMA_API_KEY=your-key  # Optional
+
+# Ollama Cloud
+# OLLAMA_CLOUD_API_KEY=your-key
+# OLLAMA_CLOUD_BASE_URL=https://ollama.com/api
+
+# OpenAI
+# OPENAI_API_KEY=sk-xxxxxxxxxxxx
+# OPENAI_BASE_URL=https://api.openai.com/v1
+# OPENAI_ORG_ID=org-xxxxxxxxxxxx
+
+# OpenCode Go
+# OPENCODE_GO_API_KEY=your-key
+# OPENCODE_GO_BASE_URL=https://api.opencode.ai/v1
+
+# OpenRouter
+# OPENROUTER_API_KEY=sk-or-xxxxxxxxxxxx
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+# OPENROUTER_REFERER=https://github.com/thomwebb/gac
+# OPENROUTER_APP_NAME=gac
+
+# Plexus Gateway
+# PLEXUS_API_KEY=your-key
+# PLEXUS_BASE_URL=https://your-gateway.example.com/v1
+
+# Qwen (International)
+# QWEN_API_KEY=your-key
+# QWEN_BASE_URL=https://dashscope-intl.aliyuncs.com/api/v1
+
+# Qwen API (International)
+# QWEN_API_KEY=your-key
+# QWEN_API_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+
+# Qwen API (China)
+# QWEN_API_KEY=your-key
+# QWEN_API_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+
+# Replicate
+# REPLICATE_API_TOKEN=r8_xxxxxxxxxxxx
+# REPLICATE_BASE_URL=https://api.replicate.com/v1
+
+# Streamlake / Vanchin
+# STREAMLAKE_API_KEY=your-key
+# STREAMLAKE_BASE_URL=https://api.streamlake.ai/v1
+
+# Synthetic.new
+# SYNTHETIC_API_KEY=your-key
+# SYNTHETIC_BASE_URL=https://api.synthetic.new/v1
+
+# Together AI
+# TOGETHER_API_KEY=your-key
+# TOGETHER_BASE_URL=https://api.together.xyz/v1
+
+# Wafer.ai
+# WAFER_API_KEY=your-key
+# WAFER_BASE_URL=https://pass.Wafer.ai
+
+# Z.ai (GLM)
+# ZAI_API_KEY=your-key
+# ZAI_BASE_URL=https://open.bigmodel.cn/api/paas/v4
+# ZAI_USE_CODING_PLAN=false
+
+# =============================================================================
+# OPTIONAL: gac Behavior Settings
+# =============================================================================
+
+# Token limits and generation
 # GAC_WARNING_LIMIT_TOKENS=128000
 # GAC_MAX_OUTPUT_TOKENS=512
 # GAC_TEMPERATURE=0.7
-# GAC_ALWAYS_INCLUDE_SCOPE=true
-# GAC_ALWAYS_GROUPED=true  # Always use grouped commit mode (equivalent to always passing the -g flag)
-# GAC_VERBOSE=true  # Generate detailed commit messages with motivation, architecture, and impact sections
-# GAC_USE_50_72_RULE=true  # Enforce 50/72 rule: subject ≤50 chars, body lines ≤72 chars
-# GAC_ZAI_USE_CODING_PLAN=false  # Set to true to use coding API endpoint instead of regular API
+# GAC_REASONING_EFFORT=medium  # low, medium, high (for models that support it)
 
-# OPTIONAL - Reasoning Effort
-# Control reasoning/thinking depth for models that support extended thinking
-# Valid values: low, medium, high. Leave unset to use the model's default.
-# Only sent to providers that support reasoning_effort (OpenAI-compatible; not Anthropic-style)
-# Default: unset (use model default)
-# GAC_REASONING_EFFORT=medium
+# Commit message options
+# GAC_ALWAYS_INCLUDE_SCOPE=true       # Always infer scope (e.g., feat(auth):)
+# GAC_ALWAYS_GROUPED=true             # Always use grouped commit mode (-g flag)
+# GAC_VERBOSE=true                    # Detailed messages with motivation, architecture, impact
+# GAC_USE_50_72_RULE=true             # Enforce 50/72 rule: subject ≤50 chars, body ≤72 chars
+# GAC_TRANSLATE_PREFIXES=true         # Translate conventional prefixes (feat, fix, etc.)
+# GAC_SIGNOFF=true                    # Add Signed-off-by line (DCO compliance)
 
-# OPTIONAL - Commit Message Editor
-# Override the editor for 'e' at the confirmation prompt (default: in-place TUI)
-# Use 'gac editor' for an interactive selector with common editors
-# GAC_EDITOR=code --wait
+# Language
+# GAC_LANGUAGE=Spanish                # Run 'uvx gac language' for interactive selection
+# GAC_RTL_CONFIRMED=true              # Suppress RTL warning (auto-set after first RTL selection)
 
-# OPTIONAL - Custom System Prompt
-# Path to a custom system prompt file that defines how commit messages should be generated
-# Write plain text instructions - no special format or tags required
-# See custom_system_prompt.example.txt for an example
-# The user prompt (git diff data) is automatically added and not customizable
+# Security
+# GAC_SKIP_SECRET_SCAN=true           # Skip secret detection (use with caution!)
+# GAC_NO_VERIFY_SSL=true              # Skip SSL verification (corporate proxies)
+
+# Hooks
+# GAC_HOOK_TIMEOUT=30                 # Pre-commit/lefthook timeout in seconds (0 = use config)
+
+# Editor for 'e' at confirmation prompt
+# GAC_EDITOR=code --wait              # Run 'uvx gac editor' for interactive selector
+
+# Custom System Prompt
 # GAC_SYSTEM_PROMPT_PATH=/path/to/custom_system_prompt.txt
 
-# OPTIONAL - Commit Message Language
-# Language for generated commit messages (e.g., Spanish, French, Japanese, German, Portuguese)
-# Use 'gac language' for an interactive selector with 25+ languages
-# The conventional commit prefix (feat:, fix:, etc.) will remain in English by default
-# All other text in the commit message will be in the specified language
-# Default: English
-# GAC_LANGUAGE=Spanish
+# Statistics
+# GAC_DISABLE_STATS=true              # Disable local usage statistics tracking
 
-# OPTIONAL - Translate Conventional Commit Prefixes
-# When true, translates conventional commit prefixes (feat, fix, docs, etc.) into the target language
-# When false (default), keeps prefixes in English for tool compatibility (changelog generators, etc.)
-# Only applies when GAC_LANGUAGE is set
-# Default: false
-# GAC_TRANSLATE_PREFIXES=true
+# Diff context (for better commit messages)
+# GAC_DIFF_CONTEXT_LINES=10           # Lines of context in diff (0-100)
 
-# OPTIONAL - Disable Usage Statistics
-# Set to true to disable local usage statistics tracking (gac stats)
-# No stats file reads or writes occur when disabled; existing data is preserved
-# Default: false
-# GAC_DISABLE_STATS=true
+# =============================================================================
+# QUICK REFERENCE: Common Provider Configurations
+# =============================================================================
+# Uncomment the block for your provider and fill in your credentials:
 
-# OPTIONAL - RTL Language Confirmation
-# When true, suppresses the RTL warning when selecting right-to-left languages
-# Automatically set after first RTL language selection to avoid repeated warnings
-# Default: false
-# GAC_RTL_CONFIRMED=true
+## Anthropic (Claude)
+# GAC_MODEL=anthropic:claude-3-5-sonnet-20241022
+# ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
+
+## OpenAI
+# GAC_MODEL=openai:gpt-4o
+# OPENAI_API_KEY=sk-xxxxxxxxxxxx
+
+## Groq (Fast, Free Tier)
+# GAC_MODEL=groq:llama-3.3-70b-versatile
+# GROQ_API_KEY=gsk_xxxxxxxxxxxx
+
+## Ollama (Local, Free)
+# GAC_MODEL=ollama:llama3.1
+# OLLAMA_API_URL=http://localhost:11434
+
+## DeepSeek (Cost-Effective)
+# GAC_MODEL=deepseek:deepseek-chat
+# DEEPSEEK_API_KEY=sk-xxxxxxxxxxxx
+
+## Gemini (Long Context)
+# GAC_MODEL=gemini:gemini-1.5-pro
+# GEMINI_API_KEY=your-gemini-key
+
+## Azure OpenAI (Enterprise)
+# GAC_MODEL=azure-openai:my-gpt4o-deployment
+# AZURE_OPENAI_API_KEY=xxxxxxxxxxxx
+# AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com
+# AZURE_OPENAI_API_VERSION=2024-10-21
+
+## OpenRouter (300+ Models)
+# GAC_MODEL=openrouter:anthropic/claude-3.5-sonnet
+# OPENROUTER_API_KEY=sk-or-xxxxxxxxxxxx
+
+## Custom OpenAI-Compatible (vLLM, TGI, LocalAI, etc.)
+# GAC_MODEL=custom-openai:my-model
+# CUSTOM_OPENAI_API_KEY=your-proxy-key
+# CUSTOM_OPENAI_BASE_URL=https://your-proxy.example.com/v1
+
+## Custom Anthropic-Compatible (Omniroute, LiteLLM, etc.)
+# GAC_MODEL=custom-anthropic:claude-3-5-sonnet-20241022
+# CUSTOM_ANTHROPIC_API_KEY=your-proxy-key
+# CUSTOM_ANTHROPIC_BASE_URL=https://your-proxy.example.com/v1
+
+# =============================================================================
+# See docs/en/PROVIDERS.md for complete documentation on all 35+ providers
+# =============================================================================

--- a/docs/en/PROVIDERS.md
+++ b/docs/en/PROVIDERS.md
@@ -1,0 +1,788 @@
+# AI Provider Configuration Guide
+
+**English** | [简体中文](../zh-CN/PROVIDERS.md) | [繁體中文](../zh-TW/PROVIDERS.md) | [日本語](../ja/PROVIDERS.md) | [한국어](../ko/PROVIDERS.md) | [हिन्दी](../hi/PROVIDERS.md) | [Tiếng Việt](../vi/PROVIDERS.md) | [Français](../fr/PROVIDERS.md) | [Русский](../ru/PROVIDERS.md) | [Español](../es/PROVIDERS.md) | [Português](../pt/PROVIDERS.md) | [Norsk](../no/PROVIDERS.md) | [Svenska](../sv/PROVIDERS.md) | [Deutsch](../de/PROVIDERS.md) | [Nederlands](../nl/PROVIDERS.md) | [Italiano](../it/PROVIDERS.md)
+
+---
+
+This guide provides configuration examples for all **35+ AI providers** supported by gac.
+
+## Quick Reference Table
+
+| Provider | Provider ID | Model Format | Auth Type | Required Env Vars | Optional Env Vars |
+|----------|-------------|--------------|-----------|-------------------|-------------------|
+| **Anthropic** | `anthropic` | `anthropic:claude-3-5-sonnet-20241022` | API Key | `ANTHROPIC_API_KEY` | — |
+| **Azure OpenAI** | `azure-openai` | `azure-openai:my-deployment-name` | API Key | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_VERSION` | — |
+| **Cerebras** | `cerebras` | `cerebras:llama3.1-8b` | API Key | `CEREBRAS_API_KEY` | `CEREBRAS_BASE_URL` |
+| **ChatGPT OAuth** | `chatgpt-oauth` | `chatgpt-oauth:gpt-4o` | OAuth | — | `CHATGPT_OAUTH_TOKEN` |
+| **Chutes.ai** | `chutes` | `chutes:deepseek-ai/DeepSeek-V3-0324` | API Key | `CHUTES_API_KEY` | `CHUTES_BASE_URL` |
+| **Claude Code** | `claude-code` | `claude-code:claude-3-5-sonnet-20241022` | OAuth | `CLAUDE_CODE_ACCESS_TOKEN` | — |
+| **Copilot (GitHub)** | `copilot` | `copilot:gpt-4o` | OAuth | — | `GITHUB_COPILOT_TOKEN` |
+| **Crof.ai** | `crof` | `crof:claude-3-5-sonnet` | API Key | `CROF_API_KEY` | `CROF_BASE_URL` |
+| **Custom Anthropic** | `custom-anthropic` | `custom-anthropic:claude-3-5-sonnet` | API Key | `CUSTOM_ANTHROPIC_API_KEY`, `CUSTOM_ANTHROPIC_BASE_URL` | `CUSTOM_ANTHROPIC_VERSION` |
+| **Custom OpenAI** | `custom-openai` | `custom-openai:gpt-4` | API Key | `CUSTOM_OPENAI_API_KEY`, `CUSTOM_OPENAI_BASE_URL` | — |
+| **DeepInfra** | `deepinfra` | `deepinfra:meta-llama/Llama-3.3-70B-Instruct` | API Key | `DEEPINFRA_API_KEY` | `DEEPINFRA_BASE_URL` |
+| **DeepSeek** | `deepseek` | `deepseek:deepseek-chat` | API Key | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
+| **Fireworks AI** | `fireworks` | `fireworks:accounts/fireworks/models/llama-v3p1-70b-instruct` | API Key | `FIREWORKS_API_KEY` | `FIREWORKS_BASE_URL` |
+| **Gemini (Google)** | `gemini` | `gemini:gemini-1.5-pro` | API Key | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| **Groq** | `groq` | `groq:llama-3.3-70b-versatile` | API Key | `GROQ_API_KEY` | `GROQ_BASE_URL` |
+| **Kimi for Coding** | `kimi-coding` | `kimi-coding:kimi-coding` | API Key | `KIMI_API_KEY` | `KIMI_BASE_URL` |
+| **Lilac** | `lilac` | `lilac:lilac-1` | API Key | `LILAC_API_KEY` | `LILAC_BASE_URL` |
+| **LM Studio** | `lm-studio` | `lm-studio:local-model-name` | Optional API Key | — | `LMSTUDIO_API_URL`, `LMSTUDIO_API_KEY` |
+| **MiniMax** | `minimax` | `minimax:abab6.5s-chat` | API Key | `MINIMAX_API_KEY` | `MINIMAX_BASE_URL` |
+| **Mistral AI** | `mistral` | `mistral:mistral-large-latest` | API Key | `MISTRAL_API_KEY` | `MISTRAL_BASE_URL` |
+| **Moonshot AI** | `moonshot` | `moonshot:moonshot-v1-8k` | API Key | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
+| **Neuralwatt** | `neuralwatt` | `neuralwatt:nemotron-3-ultra` | API Key | `NEURALWATT_API_KEY` | `NEURALWATT_BASE_URL` |
+| **Ollama** | `ollama` | `ollama:llama3.1` | Optional API Key | — | `OLLAMA_API_URL`, `OLLAMA_API_KEY` |
+| **Ollama Cloud** | `ollama-cloud` | `ollama-cloud:llama3.1` | API Key | `OLLAMA_CLOUD_API_KEY` | `OLLAMA_CLOUD_BASE_URL` |
+| **OpenAI** | `openai` | `openai:gpt-4o` | API Key | `OPENAI_API_KEY` | `OPENAI_BASE_URL`, `OPENAI_ORG_ID` |
+| **OpenCode Go** | `opencode-go` | `opencode-go:codellama` | API Key | `OPENCODE_GO_API_KEY` | `OPENCODE_GO_BASE_URL` |
+| **OpenRouter** | `openrouter` | `openrouter:anthropic/claude-3.5-sonnet` | API Key | `OPENROUTER_API_KEY` | `OPENROUTER_BASE_URL`, `OPENROUTER_REFERER`, `OPENROUTER_APP_NAME` |
+| **Plexus Gateway** | `plexus` | `plexus:gpt-4o` | API Key | `PLEXUS_API_KEY` | `PLEXUS_BASE_URL` |
+| **Qwen (Intl)** | `qwen` | `qwen:qwen-max` | API Key | `QWEN_API_KEY` | `QWEN_BASE_URL` |
+| **Qwen API (Intl)** | `qwen-api` | `qwen-api:qwen-max` | API Key | `QWEN_API_KEY` | `QWEN_API_BASE_URL` |
+| **Qwen API (CN)** | `qwen-api-cn` | `qwen-api-cn:qwen-max` | API Key | `QWEN_API_KEY` | `QWEN_API_BASE_URL` |
+| **Replicate** | `replicate` | `replicate:meta/llama-3.1-405b-instruct` | API Token | `REPLICATE_API_TOKEN` | `REPLICATE_BASE_URL` |
+| **Streamlake** | `streamlake` | `streamlake:deepseek-chat` | API Key | `STREAMLAKE_API_KEY` | `STREAMLAKE_BASE_URL` |
+| **Synthetic.new** | `synthetic` | `synthetic:gpt-4o` | API Key | `SYNTHETIC_API_KEY` | `SYNTHETIC_BASE_URL` |
+| **Together AI** | `together` | `together:meta-llama/Llama-3.3-70B-Instruct-Turbo` | API Key | `TOGETHER_API_KEY` | `TOGETHER_BASE_URL` |
+| **Wafer.ai** | `wafer` | `wafer:wafer-1` | API Key | `WAFER_API_KEY` | `WAFER_BASE_URL` |
+| **Z.ai** | `zai` | `zai:glm-4-plus` | API Key | `ZAI_API_KEY` | `ZAI_BASE_URL`, `ZAI_USE_CODING_PLAN` |
+| **Z.ai Coding** | `zai-coding` | `zai-coding:glm-4-plus` | API Key | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+
+---
+
+## Detailed Provider Configurations
+
+### 1. Anthropic (Claude)
+
+**Best for:** General-purpose coding, reasoning, long context
+
+```bash
+# .gac.env
+GAC_MODEL=anthropic:claude-3-5-sonnet-20241022
+ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
+```
+
+**Available Models:**
+- `claude-3-5-sonnet-20241022` (recommended)
+- `claude-3-5-haiku-20241022`
+- `claude-3-opus-20240229`
+
+---
+
+### 2. Azure OpenAI
+
+**Best for:** Enterprise Azure deployments, compliance requirements
+
+```bash
+# .gac.env
+GAC_MODEL=azure-openai:my-gpt4o-deployment
+AZURE_OPENAI_API_KEY=xxxxxxxxxxxx
+AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com
+AZURE_OPENAI_API_VERSION=2024-10-21
+```
+
+**Notes:**
+- Model name = **deployment name**, not model name
+- API version must match your deployment's supported version
+- Uses `api-key` header instead of Bearer token
+
+---
+
+### 3. Cerebras
+
+**Best for:** Ultra-fast inference with Llama models
+
+```bash
+# .gac.env
+GAC_MODEL=cerebras:llama3.1-8b
+CEREBRAS_API_KEY=csk-xxxxxxxxxxxx
+# Optional: CEREBRAS_BASE_URL=https://api.cerebras.ai/v1
+```
+
+---
+
+### 4. ChatGPT OAuth
+
+**Best for:** Using your ChatGPT Plus/Pro subscription
+
+```bash
+# Run interactive setup
+uvx gac init
+# Select "ChatGPT OAuth" as provider
+# Browser will open for authentication
+```
+
+**No API key needed** — uses your ChatGPT subscription via OAuth.
+
+---
+
+### 5. Chutes.ai
+
+**Best for:** Serverless inference with open models
+
+```bash
+# .gac.env
+GAC_MODEL=chutes:deepseek-ai/DeepSeek-V3-0324
+CHUTES_API_KEY=chutes_xxxxxxxxxxxx
+# Optional: CHUTES_BASE_URL=https://llm.chutes.ai/v1
+```
+
+---
+
+### 6. Claude Code (Anthropic OAuth)
+
+**Best for:** Anthropic Claude Code subscription users
+
+```bash
+# Run interactive setup
+uvx gac init
+# Select "Claude Code" as provider
+# Browser will open for authentication
+```
+
+**Requires:** Active Claude Code subscription.
+
+---
+
+### 7. GitHub Copilot
+
+**Best for:** GitHub Copilot subscribers
+
+```bash
+# Run interactive setup
+uvx gac init
+# Select "GitHub Copilot" as provider
+# Browser will open for GitHub OAuth
+```
+
+---
+
+### 8. Crof.ai
+
+**Best for:** Multi-model access via single API
+
+```bash
+# .gac.env
+GAC_MODEL=crof:claude-3-5-sonnet
+CROF_API_KEY=crof_xxxxxxxxxxxx
+# Optional: CROF_BASE_URL=https://api.crof.ai/v1
+```
+
+---
+
+### 9. Custom Anthropic-Compatible Endpoint
+
+**Best for:** Proxies, self-hosted Anthropic-compatible APIs (e.g., Omniroute, LiteLLM)
+
+```bash
+# .gac.env
+GAC_MODEL=custom-anthropic:claude-3-5-sonnet-20241022
+CUSTOM_ANTHROPIC_API_KEY=your-proxy-key
+CUSTOM_ANTHROPIC_BASE_URL=https://your-proxy.example.com/v1
+# Optional: CUSTOM_ANTHROPIC_VERSION=2023-06-01
+```
+
+**Important:** If your proxy defaults to streaming, gac automatically sends `stream: false`.
+
+---
+
+### 10. Custom OpenAI-Compatible Endpoint
+
+**Best for:** Proxies, self-hosted OpenAI-compatible APIs (vLLM, Text Generation Inference, LocalAI, etc.)
+
+```bash
+# .gac.env
+GAC_MODEL=custom-openai:gpt-4
+CUSTOM_OPENAI_API_KEY=your-proxy-key
+CUSTOM_OPENAI_BASE_URL=https://your-proxy.example.com/v1
+```
+
+**Important:** If your proxy defaults to streaming, gac automatically sends `stream: false`.
+
+---
+
+### 11. DeepInfra
+
+**Best for:** Low-cost open model inference
+
+```bash
+# .gac.env
+GAC_MODEL=deepinfra:meta-llama/Llama-3.3-70B-Instruct
+DEEPINFRA_API_KEY=your-key
+# Optional: DEEPINFRA_BASE_URL=https://api.deepinfra.com/v1/openai
+```
+
+---
+
+### 12. DeepSeek
+
+**Best for:** Cost-effective reasoning models
+
+```bash
+# .gac.env
+GAC_MODEL=deepseek:deepseek-chat
+DEEPSEEK_API_KEY=sk-xxxxxxxxxxxx
+# Optional: DEEPSEEK_BASE_URL=https://api.deepseek.com
+```
+
+**Models:**
+- `deepseek-chat` (V3)
+- `deepseek-reasoner` (R1)
+
+---
+
+### 13. Fireworks AI
+
+**Best for:** Fast inference with compound AI systems
+
+```bash
+# .gac.env
+GAC_MODEL=fireworks:accounts/fireworks/models/llama-v3p1-70b-instruct
+FIREWORKS_API_KEY=fw_xxxxxxxxxxxx
+# Optional: FIREWORKS_BASE_URL=https://api.fireworks.ai/inference/v1
+```
+
+---
+
+### 14. Google Gemini
+
+**Best for:** Long context (1M+ tokens), multimodal
+
+```bash
+# .gac.env
+GAC_MODEL=gemini:gemini-1.5-pro
+GEMINI_API_KEY=your-gemini-key
+# Optional: GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+```
+
+**Models:**
+- `gemini-1.5-pro` (1M context)
+- `gemini-1.5-flash` (fast, 1M context)
+- `gemini-2.0-flash-exp` (experimental)
+
+---
+
+### 15. Groq
+
+**Best for:** Ultra-low latency inference
+
+```bash
+# .gac.env
+GAC_MODEL=groq:llama-3.3-70b-versatile
+GROQ_API_KEY=gsk_xxxxxxxxxxxx
+# Optional: GROQ_BASE_URL=https://api.groq.com/openai/v1
+```
+
+**Models:**
+- `llama-3.3-70b-versatile`
+- `llama-3.1-8b-instant`
+- `mixtral-8x7b-32768`
+
+---
+
+### 16. Kimi for Coding
+
+**Best for:** Coding-focused model from Moonshot
+
+```bash
+# .gac.env
+GAC_MODEL=kimi-coding:kimi-coding
+KIMI_API_KEY=sk-xxxxxxxxxxxx
+# Optional: KIMI_BASE_URL=https://api.moonshot.cn/v1
+```
+
+---
+
+### 17. Lilac
+
+**Best for:** Open-source model hosting
+
+```bash
+# .gac.env
+GAC_MODEL=lilac:lilac-1
+LILAC_API_KEY=your-key
+# Optional: LILAC_BASE_URL=https://api.lilac.ai/v1
+```
+
+---
+
+### 18. LM Studio (Local)
+
+**Best for:** Running models locally with GUI
+
+```bash
+# .gac.env
+GAC_MODEL=lm-studio:my-local-model
+# Optional (defaults to http://localhost:1234):
+LMSTUDIO_API_URL=http://localhost:1234
+# Optional (if LM Studio requires auth):
+LMSTUDIO_API_KEY=your-key
+```
+
+**Setup:**
+1. Start LM Studio and load a model
+2. Start the local server (Developer → Start Server)
+3. Use the model name as shown in LM Studio
+
+---
+
+### 19. MiniMax
+
+**Best for:** Chinese language optimization, long context
+
+```bash
+# .gac.env
+GAC_MODEL=minimax:abab6.5s-chat
+MINIMAX_API_KEY=your-key
+# Optional: MINIMAX_BASE_URL=https://api.minimax.chat/v1
+```
+
+---
+
+### 20. Mistral AI
+
+**Best for:** European hosting, strong multilingual
+
+```bash
+# .gac.env
+GAC_MODEL=mistral:mistral-large-latest
+MISTRAL_API_KEY=your-key
+# Optional: MISTRAL_BASE_URL=https://api.mistral.ai/v1
+```
+
+**Models:**
+- `mistral-large-latest`
+- `mistral-small-latest`
+- `pixtral-large-latest` (multimodal)
+
+---
+
+### 21. Moonshot AI (Kimi)
+
+**Best for:** Long context, Chinese language
+
+```bash
+# .gac.env
+GAC_MODEL=moonshot:moonshot-v1-8k
+MOONSHOT_API_KEY=sk-xxxxxxxxxxxx
+# Optional: MOONSHOT_BASE_URL=https://api.moonshot.cn/v1
+```
+
+**Models:**
+- `moonshot-v1-8k`
+- `moonshot-v1-32k`
+- `moonshot-v1-128k`
+
+---
+
+### 22. Neuralwatt
+
+**Best for:** NVIDIA Nemotron models
+
+```bash
+# .gac.env
+GAC_MODEL=neuralwatt:nemotron-3-ultra
+NEURALWATT_API_KEY=your-key
+# Optional: NEURALWATT_BASE_URL=https://api.neuralwatt.ai/v1
+```
+
+---
+
+### 23. Ollama (Local)
+
+**Best for:** Fully local inference, privacy, no API costs
+
+```bash
+# .gac.env
+GAC_MODEL=ollama:llama3.1
+# Optional (defaults to http://localhost:11434):
+OLLAMA_API_URL=http://localhost:11434
+# Optional (if Ollama configured with auth):
+OLLAMA_API_KEY=your-key
+```
+
+**Setup:**
+```bash
+# Install Ollama
+curl -fsSL https://ollama.ai/install.sh | sh
+
+# Pull a model
+ollama pull llama3.1
+
+# Start Ollama server (if not running as service)
+ollama serve
+```
+
+**Popular Models:**
+- `llama3.1` / `llama3.2`
+- `qwen2.5-coder`
+- `deepseek-coder`
+- `codellama`
+- `phi3.5`
+
+---
+
+### 24. Ollama Cloud
+
+**Best for:** Managed Ollama hosting
+
+```bash
+# .gac.env
+GAC_MODEL=ollama-cloud:llama3.1
+OLLAMA_CLOUD_API_KEY=your-key
+# Optional: OLLAMA_CLOUD_BASE_URL=https://ollama.com/api
+```
+
+---
+
+### 25. OpenAI
+
+**Best for:** GPT-4o, o1 reasoning, broad compatibility
+
+```bash
+# .gac.env
+GAC_MODEL=openai:gpt-4o
+OPENAI_API_KEY=sk-xxxxxxxxxxxx
+# Optional:
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_ORG_ID=org-xxxxxxxxxxxx
+```
+
+**Models:**
+- `gpt-4o` / `gpt-4o-mini`
+- `o1-preview` / `o1-mini` (reasoning)
+- `gpt-4-turbo`
+
+---
+
+### 26. OpenCode Go
+
+**Best for:** OpenCode Go users
+
+```bash
+# .gac.env
+GAC_MODEL=opencode-go:codellama
+OPENCODE_GO_API_KEY=your-key
+# Optional: OPENCODE_GO_BASE_URL=https://api.opencode.ai/v1
+```
+
+---
+
+### 27. OpenRouter
+
+**Best for:** Access 300+ models via single API, model routing
+
+```bash
+# .gac.env
+GAC_MODEL=openrouter:anthropic/claude-3.5-sonnet
+OPENROUTER_API_KEY=sk-or-xxxxxxxxxxxx
+# Optional:
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_REFERER=https://github.com/thomwebb/gac
+OPENROUTER_APP_NAME=gac
+```
+
+**Popular Models:**
+- `anthropic/claude-3.5-sonnet`
+- `openai/gpt-4o`
+- `google/gemini-1.5-pro`
+- `meta-llama/llama-3.3-70b-instruct`
+- `deepseek/deepseek-chat`
+
+---
+
+### 28. Plexus Gateway
+
+**Best for:** Enterprise gateway with multiple providers
+
+```bash
+# .gac.env
+GAC_MODEL=plexus:gpt-4o
+PLEXUS_API_KEY=your-key
+# Optional: PLEXUS_BASE_URL=https://your-gateway.example.com/v1
+```
+
+---
+
+### 29. Qwen (International)
+
+**Best for:** Alibaba's Qwen models (international)
+
+```bash
+# .gac.env
+GAC_MODEL=qwen:qwen-max
+QWEN_API_KEY=your-key
+# Optional: QWEN_BASE_URL=https://dashscope-intl.aliyuncs.com/api/v1
+```
+
+---
+
+### 30. Qwen API (International)
+
+**Best for:** Direct Qwen API access (international)
+
+```bash
+# .gac.env
+GAC_MODEL=qwen-api:qwen-max
+QWEN_API_KEY=your-key
+# Optional: QWEN_API_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+```
+
+---
+
+### 31. Qwen API (China)
+
+**Best for:** Direct Qwen API access (China mainland)
+
+```bash
+# .gac.env
+GAC_MODEL=qwen-api-cn:qwen-max
+QWEN_API_KEY=your-key
+# Optional: QWEN_API_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+```
+
+---
+
+### 32. Replicate
+
+**Best for:** Running open models via API, pay-per-use
+
+```bash
+# .gac.env
+GAC_MODEL=replicate:meta/llama-3.1-405b-instruct
+REPLICATE_API_TOKEN=r8_xxxxxxxxxxxx
+# Optional: REPLICATE_BASE_URL=https://api.replicate.com/v1
+```
+
+---
+
+### 33. Streamlake / Vanchin
+
+**Best for:** Chinese provider, DeepSeek models
+
+```bash
+# .gac.env
+GAC_MODEL=streamlake:deepseek-chat
+STREAMLAKE_API_KEY=your-key
+# Optional: STREAMLAKE_BASE_URL=https://api.streamlake.ai/v1
+```
+
+---
+
+### 34. Synthetic.new
+
+**Best for:** Synthetic data generation, model access
+
+```bash
+# .gac.env
+GAC_MODEL=synthetic:gpt-4o
+SYNTHETIC_API_KEY=your-key
+# Optional: SYNTHETIC_BASE_URL=https://api.synthetic.new/v1
+```
+
+---
+
+### 35. Together AI
+
+**Best for:** Open model inference, fine-tuning
+
+```bash
+# .gac.env
+GAC_MODEL=together:meta-llama/Llama-3.3-70B-Instruct-Turbo
+TOGETHER_API_KEY=your-key
+# Optional: TOGETHER_BASE_URL=https://api.together.xyz/v1
+```
+
+---
+
+### 36. Wafer.ai
+
+**Best for:** High-quality inference
+
+```bash
+# .gac.env
+GAC_MODEL=wafer:wafer-1
+WAFER_API_KEY=your-key
+# Optional: WAFER_BASE_URL=https://pass.Wafer.ai
+```
+
+---
+
+### 37. Z.ai (GLM)
+
+**Best for:** Zhipu AI's GLM models
+
+```bash
+# .gac.env
+GAC_MODEL=zai:glm-4-plus
+ZAI_API_KEY=your-key
+# Optional:
+ZAI_BASE_URL=https://open.bigmodel.cn/api/paas/v4
+ZAI_USE_CODING_PLAN=false  # Set true for coding plan
+```
+
+**Models:**
+- `glm-4-plus` / `glm-4-flash`
+- `glm-4-alltools` (tool use)
+
+---
+
+### 38. Z.ai Coding
+
+**Best for:** Z.ai's coding-specialized models
+
+```bash
+# .gac.env
+GAC_MODEL=zai-coding:glm-4-plus
+ZAI_API_KEY=your-key
+# Optional: ZAI_BASE_URL=https://open.bigmodel.cn/api/paas/v4
+```
+
+---
+
+## Configuration Patterns
+
+### Using `uvx gac init` (Recommended)
+
+The interactive setup handles provider-specific prompts:
+
+```bash
+uvx gac init
+# 1. Select provider from list
+# 2. Enter model name
+# 3. Enter API key / authenticate via OAuth
+# 4. Optionally set language, output format
+# 5. Saves to .gac.env
+```
+
+### Using `uvx gac model` (Provider/Model Only)
+
+Change provider/model without reconfiguring language:
+
+```bash
+uvx gac model
+# Select new provider/model
+```
+
+### Multiple Providers
+
+You can configure multiple providers in `.gac.env` and switch via CLI:
+
+```bash
+# .gac.env
+GAC_MODEL=openai:gpt-4o
+OPENAI_API_KEY=sk-xxx
+ANTHROPIC_API_KEY=sk-ant-xxx
+GROQ_API_KEY=gsk-xxx
+
+# Switch at runtime
+uvx gac -m anthropic:claude-3-5-sonnet-20241022
+uvx gac -m groq:llama-3.3-70b-versatile
+```
+
+### Per-Project Configuration
+
+Create `.gac.env` in your project root:
+
+```bash
+# Project-specific config
+GAC_MODEL=anthropic:claude-3-5-sonnet-20241022
+ANTHROPIC_API_KEY=sk-ant-xxx
+GAC_LANGUAGE=English
+GAC_VERBOSE=true
+```
+
+Global config at `~/.gac.env` is overridden by project config.
+
+---
+
+## Provider Capabilities Matrix
+
+| Provider | Streaming | Reasoning | Tool Use | Max Context | Free Tier |
+|----------|-----------|-----------|----------|-------------|-----------|
+| Anthropic | ✅ | ✅ | ✅ | 200k | ❌ |
+| Azure OpenAI | ✅ | ✅ | ✅ | 128k | ❌ |
+| Cerebras | ❌ | ❌ | ❌ | 8k | ✅ |
+| ChatGPT OAuth | ✅ | ✅ | ✅ | 128k | Subscription |
+| Chutes | ✅ | ✅ | ❌ | 32k | ✅ |
+| Claude Code | ✅ | ✅ | ✅ | 200k | Subscription |
+| Copilot | ✅ | ✅ | ✅ | 128k | Subscription |
+| Crof | ✅ | ✅ | ✅ | 200k | ❌ |
+| Custom Anthropic | ✅ | ✅ | ✅ | Varies | Varies |
+| Custom OpenAI | ✅ | ✅ | ✅ | Varies | Varies |
+| DeepInfra | ✅ | ✅ | ❌ | 128k | ✅ |
+| DeepSeek | ✅ | ✅ | ❌ | 64k | ✅ |
+| Fireworks | ✅ | ✅ | ❌ | 128k | ✅ |
+| Gemini | ✅ | ✅ | ✅ | 1M+ | ✅ |
+| Groq | ✅ | ❌ | ❌ | 32k | ✅ |
+| Kimi Coding | ✅ | ✅ | ✅ | 128k | ❌ |
+| Lilac | ✅ | ❌ | ❌ | 32k | ❌ |
+| LM Studio | ❌ | ❌ | ❌ | Model-dependent | Local |
+| MiniMax | ✅ | ✅ | ✅ | 1M | ❌ |
+| Mistral | ✅ | ✅ | ✅ | 128k | ❌ |
+| Moonshot | ✅ | ✅ | ✅ | 128k | ❌ |
+| Neuralwatt | ✅ | ✅ | ❌ | 32k | ❌ |
+| Ollama | ❌ | ❌ | ❌ | Model-dependent | Local |
+| Ollama Cloud | ✅ | ✅ | ✅ | Model-dependent | ❌ |
+| OpenAI | ✅ | ✅ | ✅ | 128k | ❌ |
+| OpenCode Go | ✅ | ❌ | ❌ | 32k | ❌ |
+| OpenRouter | ✅ | ✅ | ✅ | Model-dependent | ✅ |
+| Plexus | ✅ | ✅ | ✅ | Varies | ❌ |
+| Qwen | ✅ | ✅ | ✅ | 128k | ❌ |
+| Replicate | ✅ | ❌ | ❌ | Model-dependent | Pay-per-use |
+| Streamlake | ✅ | ✅ | ❌ | 64k | ❌ |
+| Synthetic | ✅ | ✅ | ✅ | 128k | ❌ |
+| Together | ✅ | ✅ | ❌ | 128k | ✅ |
+| Wafer | ✅ | ✅ | ✅ | 128k | ❌ |
+| Z.ai | ✅ | ✅ | ✅ | 128k | ❌ |
+
+---
+
+## Troubleshooting
+
+### "Authentication Error" / "API Key Not Set"
+
+1. Run `uvx gac init` to reconfigure
+2. Or manually set the required env var in `.gac.env`
+3. For OAuth providers, re-run `uvx gac init` to refresh tokens
+
+### "Model Not Found"
+
+- Verify model name format: `provider:model-name`
+- Check provider's model list (some use deployment names, not model names)
+- For Azure: use deployment name, not model name
+
+### "Connection Error" / Timeout
+
+- Check `GAC_NO_VERIFY_SSL=true` for corporate proxies
+- Verify base URL is correct and accessible
+- Increase timeout: `GAC_HTTP_TIMEOUT=60`
+
+### "Rate Limited"
+
+- Wait and retry
+- Switch to a different model/provider
+- Check provider's rate limit policies
+
+### Local Models (Ollama, LM Studio) - "Connection Refused"
+
+- Ensure server is running: `ollama serve` or LM Studio "Start Server"
+- Check URL: `http://localhost:11434` (Ollama) or `http://localhost:1234` (LM Studio)
+- Try `curl http://localhost:11434/api/tags` to verify
+
+---
+
+## Adding a New Provider
+
+Want to add a provider? See [CONTRIBUTING.md](../CONTRIBUTING.md#adding-a-new-provider) for the provider implementation guide.
+
+---
+
+## See Also
+
+- [USAGE.md](USAGE.md) — Complete CLI reference
+- [CUSTOM_SYSTEM_PROMPTS.md](CUSTOM_SYSTEM_PROMPTS.md) — Customize commit message style
+- [CLAUDE_CODE.md](CLAUDE_CODE.md) — Claude Code OAuth setup
+- [CHATGPT_OAUTH.md](CHATGPT_OAUTH.md) — ChatGPT OAuth setup
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — Common issues

--- a/docs/en/USAGE.md
+++ b/docs/en/USAGE.md
@@ -761,5 +761,6 @@ GAC_DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/XXXX/YYYY'
 - For GitHub Copilot setup, see [docs/GITHUB_COPILOT.md](GITHUB_COPILOT.md)
 - For troubleshooting and advanced tips, see [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)
 - For installation and configuration, see [README.md#installation-and-configuration](README.md#installation-and-configuration)
+  - For provider configuration, see [docs/PROVIDERS.md](PROVIDERS.md)
 - To contribute, see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)
 - License information: [LICENSE](LICENSE)


### PR DESCRIPTION
  - Add docs/en/PROVIDERS.md with complete provider reference (38 providers)
  - Update .gac.env.example with all provider env vars and quick-reference blocks
  - Add cross-reference in USAGE.md Getting Help section

